### PR TITLE
Add GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Download BSC
         id: download
-        uses: B-Lang-org/download-bsc@v1
+        uses: ./
         with:
           os: ${{ matrix.os }}
           version: latest
@@ -46,7 +46,7 @@ jobs:
 
       - name: Download BSC
         id: download
-        uses: B-Lang-org/download-bsc@v1
+        uses: ./
         with:
           os: ${{ matrix.os }}
           version: ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+# Trigger the workflow on push or pull request
+on: [ push, pull_request ]
+
+jobs:
+  test-latest:
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13 ]
+      fail-fast: false
+    name: "Test latest ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download BSC
+        id: download
+        uses: B-Lang-org/download-bsc@v1
+        with:
+          os: ${{ matrix.os }}
+          version: latest
+          path: ../
+
+      - name: Build
+        run: |
+          echo Version tag: ${{steps.download.outputs.tag}}
+          echo Version hash: ${{steps.download.outputs.commit}}
+          export PATH=$PWD/../bsc/bin:$PATH
+          bsc -v
+
+  test-release:
+    strategy:
+      matrix:
+        version: [ 2023.01, 2023.07 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, macos-13 ]
+        exclude:
+          # macOS 13 was introduced at 2023.07
+          - version: 2023.01
+            os: macos-13
+      fail-fast: false
+    name: "Test release ${{ matrix.version }} ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download BSC
+        id: download
+        uses: B-Lang-org/download-bsc@v1
+        with:
+          os: ${{ matrix.os }}
+          version: ${{ matrix.version }}
+          path: ../
+
+      - name: Build
+        run: |
+          echo Version tag: ${{steps.download.outputs.tag}}
+          echo Version hahs: ${{steps.download.outputs.commit}}
+          export PATH=$PWD/../bsc/bin:$PATH
+          bsc -v


### PR DESCRIPTION
This tests downloading the latest, on all GitHub runner OSes; and the 2023.07 and 2023.01 releases, on runners for which a prebuilt tarfile exists.
