### PR TITLE
GitHub CI: Update runners, actions, and release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ jobs:
   test-latest:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-15-intel, macos-26 ]
       fail-fast: false
     name: "Test latest ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download BSC
         id: download
@@ -32,19 +32,18 @@ jobs:
   test-release:
     strategy:
       matrix:
-        version: [ 2024.01, 2024.07 ]
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15 ]
+        version: [ 2025.01.1, 2025.07 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-15-intel, macos-26 ]
         exclude:
-          # macOS 14 was introduced at 2024.07
-          - version: 2024.01
-            os: macos-14
-          # macOS 15 has not been introduced yet
-          - os: macos-15
+          # macOS 15 Intel has not been introduced yet
+          - os: macos-15-intel
+          # macOS 26 has not been introduced yet
+          - os: macos-26
       fail-fast: false
     name: "Test release ${{ matrix.version }} ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download BSC
         id: download


### PR DESCRIPTION
Removes `ubuntu-20.04` and `macos-13`.  Adds `macos-15-intel` and `macos-26`, which aren't introduced in a release yet.  Updates the tested release versions to 2025.01.1 and 2025.07.